### PR TITLE
info.rkt: fix license definition

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -8,4 +8,4 @@
 (define pkg-desc "Description Here")
 (define version "0.1")
 (define pkg-authors '(kurinoku))
-(define license '(MIT))
+(define license 'MIT)


### PR DESCRIPTION
A single "license-id" should not be wrapped in a list.

+ For reference see:
  - https://docs.racket-lang.org/pkg/metadata.html
  - https://github.com/Metaxal/quickscript-test/commit/d6aa7d1a0145901184c47e4439683dd4eb118b71

Signed-off-by: Maciej Barć <xgqt@gentoo.org>